### PR TITLE
Added SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
     targets: [
         .target(
             name: "Cachyr",
-            dependencies: []),
+            dependencies: [],
+            path: "Sources"),
         .testTarget(
             name: "CachyrTests",
             dependencies: ["Cachyr"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,27 @@
+// swift-tools-version:3.0
 import PackageDescription
 
 let package = Package(
-    name: "Cachyr"
+    name: "Cachyr",
+    platforms: [
+        .macOS(.v10_12),
+        .iOS(.v10),
+        .tvOS(.v10),
+        .watchOS(.v3)
+    ],
+    products: [
+        .library(
+            name: "Cachyr",
+            targets: ["Cachyr"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Cachyr",
+            dependencies: []),
+        .testTarget(
+            name: "CachyrTests",
+            dependencies: ["Cachyr"]),
+    ],
+    swiftLanguageVersions: [.v3, .v4, .v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:3.0
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
@@ -23,5 +23,5 @@ let package = Package(
             name: "CachyrTests",
             dependencies: ["Cachyr"]),
     ],
-    swiftLanguageVersions: [.v3, .v4, .v5]
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
Hi,

With Xcode 11 it's now possible to add SPM frameworks to iOS/macOS projects without too much hassle. I added the required manifest for SPM to work.

When/if you accept this PR, tag the new version as a release (the tag should be plain semver, so `1.3.1` not `v1.3.1`) and everything should work right away!

Thanks.